### PR TITLE
static ELASTICSEARCH_CLUSTERNAME value parameterized

### DIFF
--- a/templates/etl/docker-compose.yml
+++ b/templates/etl/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       KAFKA_BOOTSTRAPSERVERS: kafka:9092
       SPRING_PROFILES_ACTIVE: prod
       IMPORTER_FULLURLSIMULATE: http://simulate:8084
-      ELASTICSEARCH_CLUSTERNAME: skalogs-demo
-      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: skalogs-demo
+      ELASTICSEARCH_CLUSTERNAME: {{elasticsearch_cluster_name}}
+      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: {{elasticsearch_cluster_name}}
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PASSWORD: changeme
       ELASTICSEARCH_PORT: '9200'

--- a/templates/importer/docker-compose.yml
+++ b/templates/importer/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   process-importer:
     image: skalogs/process-importer:{{etl_version}}
     environment:
-      ELASTICSEARCH_CLUSTERNAME: skalogs-demo
-      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: skalogs-demo
+      ELASTICSEARCH_CLUSTERNAME: {{elasticsearch_cluster_name}}
+      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: {{elasticsearch_cluster_name}}
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PASSWORD: changeme
       ELASTICSEARCH_PORT: '9200'
@@ -38,8 +38,8 @@ services:
     mem_limit: 636870912
     image: skalogs/metric-importer:{{etl_version}}
     environment:
-      ELASTICSEARCH_CLUSTERNAME: skalogs-demo
-      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: skalogs-demo
+      ELASTICSEARCH_CLUSTERNAME: {{elasticsearch_cluster_name}}
+      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: {{elasticsearch_cluster_name}}
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PASSWORD: changeme
       ELASTICSEARCH_PORT: '9200'
@@ -73,8 +73,8 @@ services:
     mem_limit: 636870912
     image: skalogs/error-importer:{{etl_version}}
     environment:
-      ELASTICSEARCH_CLUSTERNAME: skalogs-demo
-      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: skalogs-demo
+      ELASTICSEARCH_CLUSTERNAME: {{elasticsearch_cluster_name}}
+      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: {{elasticsearch_cluster_name}}
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PASSWORD: changeme
       ELASTICSEARCH_PORT: '9200'
@@ -99,8 +99,8 @@ services:
     mem_limit: 636870912
     image: skalogs/retry-importer:{{etl_version}}
     environment:
-      ELASTICSEARCH_CLUSTERNAME: skalogs-demo
-      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: skalogs-demo
+      ELASTICSEARCH_CLUSTERNAME: {{elasticsearch_cluster_name}}
+      ELASTICSEARCH_CUSTOM_INDEX_PREFIX: {{elasticsearch_cluster_name}}
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_PASSWORD: changeme
       ELASTICSEARCH_PORT: '9200'


### PR DESCRIPTION
Existing stack files using static values.
This causes data creation problem on Elastic/Kibana side.