### PR TITLE
Package values changed for Ubuntu 18.04

### DIFF
--- a/group_vars/all/skalogs
+++ b/group_vars/all/skalogs
@@ -165,3 +165,6 @@ spring_mail_properties_mail_smtp_starttls_enable: true
 buffer_elasticsearch_max_elements: 10000
 buffer_elasticsearch_max_size: 1
 buffer_elasticsearch_max_time: 1
+
+docker_version: 18.06.0~ce~3-0~ubuntu
+docker_compose_version: 1.17.1-2


### PR DESCRIPTION
After updating Ansible modules, facing with version issue for Docker and Docker-compose.
To fix this error added values to vars file:
docker_version: 18.06.0~ce~3-0~ubuntu
docker_compose_version: 1.17.1-2

FAILED! => {“cache_update_time”: 1535974393, “cache_updated”: false, “changed”: false, “msg”: “’/usr/bin/apt-get -y -o \“Dpkg::Options::=--force-confdef\” -o \“Dpkg::Options::=--force-confold\”     install ‘docker-ce=18.02.0~ce-0~ubuntu’' failed: E: Version ‘18.02.0~ce-0~ubuntu’ for ‘docker-ce’ was not found\n”, “rc”: 100, “stderr”: “E: Version ‘18.02.0~ce-0~ubuntu’ for ‘docker-ce’ was not found\n”, “stderr_lines”: [“E: Version ‘18.02.0~ce-0~ubuntu’ for ‘docker-ce’ was not found”],

TASK [AdopteUnOps.docker : Install Docker-compose package] *******************************************************************
fatal: [host-master]: FAILED! => {"cache_update_time": 1535982875, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'docker-compose=1.8.0-2~16.04.1'' failed: E: Version '1.8.0-2~16.04.1' for 'docker-compose' was not found\n", "rc": 100, "stderr": "E: Version '1.8.0-2~16.04.1' for 'docker-compose' was not found\n", "stderr_lines": ["E: Version '1.8.0-2~16.04.1' for 'docker-compose' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}